### PR TITLE
Allow property names to be used for format validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ A regular expression to test with the value
 
 #### Options ####
   * `message` - Any string you wish to be the error message. Overrides `i18n`.
-  * `allowBlank` - If `true` skips validation if value is empty
-  * `with` - The regular expression to test with
+  * `allowBlank` - If `true` skips validation if value is empty.
+  * `with` - The regular expression to test with. Also accepts the string representation of a property that returns a regular expression.
 
 ```javascript
 // Examples

--- a/addon/validators/local/format.js
+++ b/addon/validators/local/format.js
@@ -16,12 +16,19 @@ export default Base.extend({
       set(this, 'options.message',  Messages.render('invalid', this.options));
     }
    },
+   getValue: function() {
+     if (this.options['with'].constructor === String) {
+       return new RegExp(this.model.get(this.options['with'])) || /.*/;
+     } else {
+       return this.options['with'];
+     }
+   },
    call: function() {
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined) {
         this.errors.pushObject(this.options.message);
       }
-    } else if (this.options['with'] && !this.options['with'].test(get(this.model, this.property))) {
+    } else if (this.options['with'] && !this.getValue().test(get(this.model, this.property))) {
       this.errors.pushObject(this.options.message);
     } else if (this.options.without && this.options.without.test(get(this.model, this.property))) {
       this.errors.pushObject(this.options.message);


### PR DESCRIPTION
String representations of property names that return regular expressions
will be accepted by the format validation. For instance, if a model has
a property, `attributeFormatter`, which returns `/\d+/`, then the
following validation syntax is legitimate:

```javascript
validations: {
  attribute: {
    format: {
      with: 'attributeFormatter'
    }
  }
}
```

My particular use-case requires format validations to be dependent on some other model property. For example, validating zip code formats would depend on a country or region.