### PR TITLE
Add allowDigitGroupSeparators to numericality

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Will ensure the value is a number
 #### Options ####
   * `true` - Passing just `true` will activate validation and use default message
   * `allowBlank` - If `true` skips validation if value is empty
+  * `allowDigitGroupSeparators` - If `true` allows commas every 3 digits, i.e. `123,456`
   * `onlyInteger` - Will only allow integers
   * `greaterThan` - Ensures the value is greater than
   * `greaterThanOrEqualTo` - Ensures the value is greater than or equal to

--- a/README.md
+++ b/README.md
@@ -211,8 +211,9 @@ Will ensure the value is a number
 
 #### Options ####
   * `true` - Passing just `true` will activate validation and use default message
+  * `decimalMark` - The character representing the decimal mark. Defaults to `'.'`
   * `allowBlank` - If `true` skips validation if value is empty
-  * `allowDigitGroupSeparators` - If `true` allows commas every 3 digits, i.e. `123,456`
+  * `allowDigitGroupSeparators` - If `true` allows commas every 3 digits, i.e. `123,456`. You optionally may supply the separator character instead of `true`
   * `onlyInteger` - Will only allow integers
   * `greaterThan` - Ensures the value is greater than
   * `greaterThanOrEqualTo` - Ensures the value is greater than or equal to

--- a/addon/patterns.js
+++ b/addon/patterns.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Namespace.create({
-  number: /^(-|\+)?\d+(?:\.\d*)?$/,
-  number_with_digit_group_separators: /^(-|\+)?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d*)?$/,
-  blank: /^\s*$/
+  blank: /^\s*$/,
+  escape: function(str) {
+    // http://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711#3561711
+    return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  }
 });

--- a/addon/patterns.js
+++ b/addon/patterns.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Namespace.create({
-  numericality: /^(-|\+)?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d*)?$/,
+  number: /^(-|\+)?\d+(?:\.\d*)?$/,
+  number_with_digit_group_separators: /^(-|\+)?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d*)?$/,
   blank: /^\s*$/
 });

--- a/addon/validators/local/numericality.js
+++ b/addon/validators/local/numericality.js
@@ -59,12 +59,15 @@ export default Base.extend({
   },
   call: function() {
     var check, checkValue, fn, operator;
+    var numberPattern = this.options.allowDigitGroupSeparators ?
+      Patterns.number_with_digit_group_separators :
+      Patterns.number;
 
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined) {
         this.errors.pushObject(this.options.messages.numericality);
       }
-    } else if (!Patterns.numericality.test(get(this.model, this.property))) {
+    } else if (!numberPattern.test(get(this.model, this.property))) {
       this.errors.pushObject(this.options.messages.numericality);
     } else if (this.options.onlyInteger === true && !(/^[+\-]?\d+$/.test(get(this.model, this.property)))) {
       this.errors.pushObject(this.options.messages.onlyInteger);

--- a/addon/validators/local/numericality.js
+++ b/addon/validators/local/numericality.js
@@ -8,7 +8,7 @@ var get = Ember.get;
 export default Base.extend({
   init: function() {
     /*jshint expr:true*/
-    var index, keys, key;
+    var index, keys, key, digitGroupSeparator, decimalMark;
     this._super();
 
     if (this.options === true) {
@@ -49,6 +49,30 @@ export default Base.extend({
         }
       }
     }
+
+    if (this.options.allowDigitGroupSeparators === true) {
+      digitGroupSeparator = ',';
+    } else if (this.options.allowDigitGroupSeparators !== undefined) {
+      digitGroupSeparator = Patterns.escape(this.options.allowDigitGroupSeparators);
+    }
+
+    if (this.options.decimalMark !== undefined) {
+      decimalMark = Patterns.escape(this.options.decimalMark);
+    } else {
+      decimalMark = '\\.';
+    }
+
+    if (this.options.onlyInteger) {
+      if (digitGroupSeparator !== undefined) {
+        this.pattern = new RegExp('^(-|\\+)?(?:\\d+|\\d{1,3}(?:' +digitGroupSeparator+ '\\d{3})+)$');
+      } else {
+        this.pattern = /^(-|\+)?\d+$/;
+      }
+    } else if (digitGroupSeparator !== undefined) {
+      this.pattern = new RegExp('^(-|\\+)?(?:\\d+|\\d{1,3}(?:' +digitGroupSeparator+ '\\d{3})+)(?:' +decimalMark+ '\\d*)?$');
+    } else {
+      this.pattern = new RegExp('^(-|\\+)?\\d+(?:' +decimalMark+ '\\d*)?$');
+    }
   },
   CHECKS: {
     equalTo              :'===',
@@ -59,18 +83,17 @@ export default Base.extend({
   },
   call: function() {
     var check, checkValue, fn, operator;
-    var numberPattern = this.options.allowDigitGroupSeparators ?
-      Patterns.number_with_digit_group_separators :
-      Patterns.number;
 
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined) {
         this.errors.pushObject(this.options.messages.numericality);
       }
-    } else if (!numberPattern.test(get(this.model, this.property))) {
-      this.errors.pushObject(this.options.messages.numericality);
-    } else if (this.options.onlyInteger === true && !(/^[+\-]?\d+$/.test(get(this.model, this.property)))) {
-      this.errors.pushObject(this.options.messages.onlyInteger);
+    } else if (!this.pattern.test(get(this.model, this.property))) {
+      if (this.options.onlyInteger === true) {
+        this.errors.pushObject(this.options.messages.onlyInteger);
+      } else {
+        this.errors.pushObject(this.options.messages.numericality);
+      }
     } else if (this.options.odd  && parseInt(get(this.model, this.property), 10) % 2 === 0) {
       this.errors.pushObject(this.options.messages.odd);
     } else if (this.options.even && parseInt(get(this.model, this.property), 10) % 2 !== 0) {

--- a/tests/unit/validators/local/numericality-test.js
+++ b/tests/unit/validators/local/numericality-test.js
@@ -60,6 +60,38 @@ test('when allowing digit group separators and value is a number with digit grou
   deepEqual(validator.errors, []);
 }); 
 
+test('when allowing specific digit group separators and value is a number using that separator', function() {
+  options = { messages: { numericality: 'failed validation' }, allowDigitGroupSeparators: "'" };
+  Ember.run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', "123'456'789");
+  });
+  deepEqual(validator.errors, []);
+});
+
+test('when allowing specific digit group separators that include regex special characters', function() {
+  options = { messages: { numericality: 'failed validation' }, allowDigitGroupSeparators: '.' };
+  Ember.run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '123.456.789');
+  });
+  deepEqual(validator.errors, []);
+});
+
+test('when specifying a decimal mark', function() {
+  options = { messages: { numericality: 'failed validation' }, decimalMark: ',' };
+  Ember.run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '123,45');
+  });
+  deepEqual(validator.errors, []);
+
+  Ember.run(function() {
+    set(model, 'attribute', '123.45');
+  });
+  deepEqual(validator.errors, ['failed validation']);
+});
+
 test('when no value', function() {
   options = { messages: { numericality: 'failed validation' } };
   Ember.run(function() {
@@ -121,6 +153,54 @@ test('when only integer is passed directly', function() {
     set(model, 'attribute', 1.1);
   });
   deepEqual(validator.errors, ['must be an integer']);
+});
+
+test('when combining integer validation with digit group separator', function() {
+  options = { onlyInteger: true, allowDigitGroupSeparators: true };
+  Ember.run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '123,456');
+  });
+  deepEqual(validator.errors, []);
+
+  Ember.run(function() {
+    set(model, 'attribute', '123456');
+  });
+  deepEqual(validator.errors, []);
+
+  Ember.run(function() {
+    set(model, 'attribute', '123456.78');
+  });
+  deepEqual(validator.errors, ['must be an integer']);
+});
+
+test('when combining decimal mark and digit group separator', function() {
+  options = { messages: { numericality: 'failed validation' }, decimalMark: ',', allowDigitGroupSeparators: '.' };
+  Ember.run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '123.456,78');
+  });
+  deepEqual(validator.errors, []);
+
+  Ember.run(function() {
+    set(model, 'attribute', '123456,78');
+  });
+  deepEqual(validator.errors, []);
+
+  Ember.run(function() {
+    set(model, 'attribute', '123.456.789');
+  });
+  deepEqual(validator.errors, []);
+
+  Ember.run(function() {
+    set(model, 'attribute', '123456');
+  });
+  deepEqual(validator.errors, []);
+
+  Ember.run(function() {
+    set(model, 'attribute', '123,456.78');
+  });
+  deepEqual(validator.errors, ['failed validation']);
 });
 
 test('when only allowing values greater than 10 and value is greater than 10', function() {

--- a/tests/unit/validators/local/numericality-test.js
+++ b/tests/unit/validators/local/numericality-test.js
@@ -42,6 +42,24 @@ test('when value is not a number', function() {
   deepEqual(validator.errors, ['failed validation']);
 });
 
+test('when value is a number with digit group separators', function() {
+  options = { messages: { numericality: 'failed validation' } };
+  Ember.run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '123,456,789');
+  });
+  deepEqual(validator.errors, ['failed validation']);
+});
+
+test('when allowing digit group separators and value is a number with digit group separators', function() {
+  options = { messages: { numericality: 'failed validation' }, allowDigitGroupSeparators: true };
+  Ember.run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '123,456,789');
+  });
+  deepEqual(validator.errors, []);
+}); 
+
 test('when no value', function() {
   options = { messages: { numericality: 'failed validation' } };
   Ember.run(function() {


### PR DESCRIPTION
Alters the default behavior of the numericality validator to more
closely-match what can be parsed by `Number(value)`.

The previous behavior - which allowed numbers such as 1,234 - can be
re-enabled via passing `allowDigitGroupSeparators: true` as an option.

For completeness and internationalization this also supports passing a
character to use as the separator, `allowDigitGroupSeparators: '.'` as well
as adding a `decimalMark: ','` option (default is `'.'`). Used together this
adds support for validating european-style currency numbers such as
1.234.567,89 successfully.

Fixes #225