### PR TITLE
Remove the use of eval to be CSP compliant

### DIFF
--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -87,5 +87,16 @@ export default Ember.Object.extend({
     } else {
       return true;
     }
+  },
+  compare: function (a, b, operator) {
+    switch (operator) {
+      case '==':  return a == b; // jshint ignore:line
+      case '===': return a === b;
+      case '>=':  return a >= b;
+      case '<=':  return a <= b;
+      case '>':   return a > b;
+      case '<':   return a < b;
+      default:    return false;
+    }
   }
 });

--- a/addon/validators/local/length.js
+++ b/addon/validators/local/length.js
@@ -72,7 +72,7 @@ export default Base.extend({
     }
   },
   call: function() {
-    var fn, operator, key;
+    var key, comparisonResult;
 
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined && (this.options.is || this.options.minimum)) {
@@ -80,13 +80,16 @@ export default Base.extend({
       }
     } else {
       for (key in this.CHECKS) {
-        operator = this.CHECKS[key];
         if (!this.options[key]) {
           continue;
         }
 
-        fn = new Function('return ' + this.options.tokenizer(get(this.model, this.property)).length + ' ' + operator + ' ' + this.getValue(key));
-        if (!fn()) {
+        comparisonResult = this.compare(
+          this.options.tokenizer(get(this.model, this.property)).length,
+          this.getValue(key),
+          this.CHECKS[key]
+        );
+        if (!comparisonResult) {
           this.errors.pushObject(this.renderMessageFor(key));
         }
       }

--- a/addon/validators/local/numericality.js
+++ b/addon/validators/local/numericality.js
@@ -51,14 +51,14 @@ export default Base.extend({
     }
   },
   CHECKS: {
-    equalTo              :'===',
+    equalTo              : '===',
     greaterThan          : '>',
     greaterThanOrEqualTo : '>=',
     lessThan             : '<',
     lessThanOrEqualTo    : '<='
   },
   call: function() {
-    var check, checkValue, fn, operator;
+    var check, checkValue, comparisonResult;
 
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined) {
@@ -74,8 +74,6 @@ export default Base.extend({
       this.errors.pushObject(this.options.messages.even);
     } else {
       for (check in this.CHECKS) {
-        operator = this.CHECKS[check];
-
         if (this.options[check] === undefined) {
           continue;
         }
@@ -86,9 +84,13 @@ export default Base.extend({
           checkValue = get(this.model, this.options[check]);
         }
 
-        fn = new Function('return ' + get(this.model, this.property) + ' ' + operator + ' ' + checkValue);
+        comparisonResult = this.compare(
+          get(this.model, this.property),
+          checkValue,
+          this.CHECKS[check]
+        );
 
-        if (!fn()) {
+        if (!comparisonResult) {
           this.errors.pushObject(this.options.messages[check]);
         }
       }

--- a/tests/unit/validators/remote/uniqueness_test.js
+++ b/tests/unit/validators/remote/uniqueness_test.js
@@ -1,3 +1,4 @@
+if (false) {} // remove this line. It is only here to fix issue #232
 // module('Uniqueness options', {
   // setup: function() {
     // Ember.Validations.forms['new_user'] = {


### PR DESCRIPTION
The code was using `new Function` with is not compliant with CSP for `script-src` unless you set it to `'eval-unsafe'`. Which you obviously don't want to do for security reason.

This PR will solve this error message in the console:

```
[Report Only] Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'". [length.js:92]
```

If you don't know what I am talking about, here are two articles:
https://developer.chrome.com/extensions/contentSecurityPolicy#restrictions
http://www.html5rocks.com/en/tutorials/security/content-security-policy/