### PR TITLE
Clarify confirmation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ acceptance: { message: 'you must accept', accept: 'yes' }
 
 ### Confirmation ###
 Expects a `propertyConfirmation` to have the same value as
-`property`
+`property`. The validation must be applied to the `property`, not the `propertyConfirmation` (otherwise it would expect a `propertyConfirmationConfirmation`).
 
 #### Options ####
   * `true` - Passing just `true` will activate validation and use default message


### PR DESCRIPTION
I wasted 15 minutes to figure that one out. To me it seemed more logicial to validate `confirmation` on the actual `propertyConfirmation` field. This is just to avoid anyone else to waste time on this.