### PR TITLE
:ambulance: Length validator would fail on non-string values.

### DIFF
--- a/addon/validators/local/length.js
+++ b/addon/validators/local/length.js
@@ -25,7 +25,7 @@ export default Base.extend({
       }
     }
 
-    this.options.tokenizer = this.options.tokenizer || function(value) { return value.split(''); };
+    this.options.tokenizer = this.options.tokenizer || function(value) { return value.toString().split(''); };
     // if (typeof(this.options.tokenizer) === 'function') {
       // debugger;
       // // this.tokenizedLength = new Function('value', 'return '

--- a/tests/unit/validators/local/length-test.js
+++ b/tests/unit/validators/local/length-test.js
@@ -169,6 +169,15 @@ test('when allowed length maximum is 3, value length is 4 and no message is set'
   deepEqual(validator.errors, ['is too long (maximum is 3 characters)']);
 });
 
+test('when value is non-string, then the value is still checked', function() {
+  options = { maximum: 3 };
+  Ember.run(function() {
+    validator = Length.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', 1234);
+  });
+  deepEqual(validator.errors, ['is too long (maximum is 3 characters)']);
+});
+
 test('when using a property instead of a number', function() {
   options = { is: 'countProperty' };
   Ember.run(function() {


### PR DESCRIPTION
Called toString() on value to ensure that we can use the default tokenizer.