### PR TITLE
Add comment about calling _super when overriding init

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ export default Ember.Component.extend({
 This is useful for things like Components which don't act as proxies, but
 again, until this is officially built into the project, YMMV.
 
+**Note: If you override the init function, you must call _super()**
+
+```javascript
+export default Ember.ObjectController.extend({
+  init: function() {
+    // this call is necessary, don't forget it!
+    this._super();
+
+    // Your init code...
+  }
+});
+```
 
 ## Validators ##
 


### PR DESCRIPTION
I'm using init in my controller for something unrelated to validations and was receiving errors related to validations.  It took me a while to figure out it was due to overriding init.  The docs mention calling _super, but only related to creating your own validator, so when investigating, I skipped that section thinking it was unrelated.  