### PR TITLE
Update README.md, add 'service:validations'

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,8 @@ the validations during testing.
 import { test, moduleFor } from 'ember-qunit';
 
 moduleFor('controller:user/edit', 'UserEditController', {
-  needs: ['ember-validations@validator:local/presence',
+  needs: ['service:validations',
+          'ember-validations@validator:local/presence',
           'ember-validations@validator:local/length',
           'validator:local/name',
           'validator:local/email'


### PR DESCRIPTION
To get the unit tests to pass in a controller with the EmberValidations.Mixin, it's necessary to add `'service:validations'` to the needs hook using `ember-cli 0.1.10`.

If you don't add the validations service you get: 

```
Error: Assertion Failed: Cannot call get with 'cache' on an undefined object.
    at new Error (native)
    at Error.EmberError (http://localhost:4200/assets/vendor.js:27294:23)
    at Object.Ember.assert (http://localhost:4200/assets/vendor.js:17447:15)
    at get (http://localhost:4200/assets/vendor.js:31104:13)
    at lookupValidator (http://localhost:4200/assets/vendor.js:91401:17)
    at exports.default.Ember.default.Mixin.create.buildRuleValidator (http://localhost:4200/assets/vendor.js:91505:68)
    at exports.default.Ember.default.Mixin.create.buildValidators (http://localhost:4200/assets/vendor.js:91471:16)
    at exports.default.Ember.default.Mixin.create.init (http://localhost:4200/assets/vendor.js:91453:12)
    at apply (http://localhost:4200/assets/vendor.js:33206:32)
    at superWrapper [as init] (http://localhost:4200/assets/vendor.js:32780:15)
```