### PR TITLE
Init validations separately from init()

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -87,7 +87,7 @@ export default Ember.Mixin.create(setValidityMixin, {
   },
   initValidations: function() {
     this._super();
-    this.errors = Errors.create();
+    this.set('errors', Errors.create());
     this.dependentValidationKeys = {};
     this.validators = Ember.A();
     if (get(this, 'validations') === undefined) {

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -83,6 +83,10 @@ var ArrayValidatorProxy = Ember.ArrayProxy.extend(setValidityMixin, {
 export default Ember.Mixin.create(setValidityMixin, {
   init: function() {
     this._super();
+    this.initValidations();
+  },
+  initValidations: function() {
+    this._super();
     this.errors = Errors.create();
     this.dependentValidationKeys = {};
     this.validators = Ember.A();


### PR DESCRIPTION
Allows to apply validations to existing model instance.

Useful in situation when you're displaying longer list of items that are very unlikely to be edited - adding validations to everything right away slows it unnecessarily. This way, you can have model without mixin and only when you want to edit it, you apply() the mixin and call initValidations() on it.