### PR TITLE
Fixes validate properties test helpers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.2.8",
+    "ember-qunit": "0.3.1",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1"
   }

--- a/tests/unit/helpers/validate-properties-test.js
+++ b/tests/unit/helpers/validate-properties-test.js
@@ -4,6 +4,8 @@ import {
   testInvalidPropertyValues
 } from '../../helpers/validate-properties';
 
+var _deepEqual;
+
 moduleFor('controller:foo', 'Unit - Foo Controller Test', {
   needs: [
     'ember-validations@validator:local/presence',
@@ -24,5 +26,54 @@ testInvalidPropertyValues('baz', ['', null, undefined], function(subject) {
 });
 
 testValidPropertyValues('baz', ['Winston', '12345', null, undefined, ''], function(subject) {
+  subject.set('isBaz', false);
+});
+
+
+moduleFor('controller:foo', 'Unit - Ensure validate properties test helpers fail when invalid', {
+  needs: [
+    'ember-validations@validator:local/presence',
+    'ember-validations@validator:local/length'
+  ],
+
+  beforeEach: function(assert) {
+    // use inverse of deepEqual to ensure the test helpers fail when invalid
+    assert.deepEqual = assert.notDeepEqual;
+  }
+});
+
+testValidPropertyValues('bar', [undefined, 'Winston', '12345']);
+testValidPropertyValues('bar', ['Winston', undefined, '12345']);
+testValidPropertyValues('bar', ['Winston', '12345', undefined]);
+
+testInvalidPropertyValues('bar', ['', null, undefined, 'abc', 'Winston']);
+testInvalidPropertyValues('bar', ['Winston', null, undefined, 'abc']);
+testInvalidPropertyValues('bar', [null, 'Winston', undefined, 'abc']);
+
+testInvalidPropertyValues('baz', ['Winston', '12345'], function(subject) {
+  subject.set('isBaz', true);
+});
+
+testValidPropertyValues('baz', [undefined, 'Winston', '12345'], function(subject) {
+  subject.set('isBaz', true);
+});
+testValidPropertyValues('baz', ['Winston', '12345', undefined], function(subject) {
+  subject.set('isBaz', true);
+});
+testValidPropertyValues('baz', ['Winston', undefined, '12345'], function(subject) {
+  subject.set('isBaz', true);
+});
+
+testInvalidPropertyValues('baz', ['', null, undefined, 'Winston'], function(subject) {
+  subject.set('isBaz', true);
+});
+testInvalidPropertyValues('baz', ['Winston', null, undefined], function(subject) {
+  subject.set('isBaz', true);
+});
+testInvalidPropertyValues('baz', ['', null, 'Winston', undefined], function(subject) {
+  subject.set('isBaz', true);
+});
+
+testInvalidPropertyValues('baz', ['Winston', '12345', null, undefined, ''], function(subject) {
   subject.set('isBaz', false);
 });


### PR DESCRIPTION
The test helpers were validating the wrong value in the array due to run loop and
promise issues. So, the order of values in the array passed to the test helper functions would
affect the results. This PR chains the promises to run sequentially to fix this problem.

Added tests to confirm that the test helpers failed appropriately with different value orders