### PR TITLE
Ensuring we get correct properties to compare to when model property is blank

### DIFF
--- a/addon/validators/local/length.js
+++ b/addon/validators/local/length.js
@@ -44,7 +44,9 @@ export default Base.extend({
     'maximum' : 'tooLong'
   },
   getValue: function(key) {
-    if (this.options[key].constructor === String) {
+    if (typeof this.options[key] === "undefined" || this.options[key] === null) {
+      return false;
+    } else if (this.options[key].constructor === String) {
       return get(this.model, this.options[key]) || 0;
     } else {
       return this.options[key];
@@ -75,7 +77,7 @@ export default Base.extend({
     var key, comparisonResult;
 
     if (Ember.isEmpty(get(this.model, this.property))) {
-      if (this.options.allowBlank === undefined && (this.options.is || this.options.minimum)) {
+      if (this.options.allowBlank === undefined && (this.getValue('is') || this.getValue('minimum'))) {
         this.errors.pushObject(this.renderBlankMessage());
       }
     } else {

--- a/tests/unit/validators/local/length-test.js
+++ b/tests/unit/validators/local/length-test.js
@@ -196,3 +196,23 @@ test('when using a property instead of a number', function(assert) {
   });
   assert.deepEqual(validator.errors, ['is the wrong length (should be 5 characters)']);
 });
+
+test('when using a property for "minimum" and model property is 0 allow blank', function(assert) {
+  options = { minimum: 'minLength' };
+  run(function() {
+    set(model, 'minLength', 0);
+    validator = Length.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '');
+  });
+  assert.deepEqual(validator.errors, []);
+});
+
+test('when using property for "is" and model property is 0 allow blank', function(assert) {
+  options = { is: 'isLength' };
+  run(function() {
+    set(model, 'isLength', 0);
+    validator = Length.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '');
+  });
+  assert.deepEqual(validator.errors, []);
+});


### PR DESCRIPTION
We are loading our validations from the database and they are coming from model properties. We have some validation lengths set to 0, and it's saying the length is invalid because it was previously checking if the option existed vs the actual model property. This checks the option property against the correct value now. 