### PR TITLE
Compare numbers

### DIFF
--- a/addon/validators/local/numericality.js
+++ b/addon/validators/local/numericality.js
@@ -85,8 +85,8 @@ export default Base.extend({
         }
 
         comparisonResult = this.compare(
-          get(this.model, this.property),
-          checkValue,
+          parseFloat(get(this.model, this.property)),
+          parseFloat(checkValue),
           this.CHECKS[check]
         );
 

--- a/tests/unit/validators/local/numericality-test.js
+++ b/tests/unit/validators/local/numericality-test.js
@@ -26,6 +26,15 @@ test('when value is a number', function(assert) {
   assert.deepEqual(validator.errors, []);
 });
 
+test('when value is a string repreenting a number', function(assert) {
+  options = { messages: { numericality: 'failed validation' } };
+  run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '123');
+  });
+  assert.deepEqual(validator.errors, []);
+});
+
 test('when value is a decimal number', function(assert) {
   options = { messages: { numericality: 'failed validation' } };
   run(function() {
@@ -114,6 +123,15 @@ test('when only allowing values greater than 10 and value is greater than 10', f
     set(model, 'attribute', 11);
   });
   assert.deepEqual(validator.errors, []);
+});
+
+test('when only allowing values greater than 10 in string and value is 2 in string', function(assert) {
+  options = { messages: { greaterThan: 'failed validation', numericality: 'failed validation' }, greaterThan: '10' };
+  run(function() {
+    validator = Numericality.create({model: model, property: 'attribute', options: options});
+    set(model, 'attribute', '2');
+  });
+  assert.deepEqual(validator.errors, ['failed validation']);
 });
 
 test('when only allowing values greater than 10 and value is 10', function(assert) {


### PR DESCRIPTION
A string representation of the number is usually accepted as valid. See, for example, the 'when value is a string representing a number' test. One would then expect that when comparing two string representation of numbers, the greaterThan and similar checks, compare numbers and not strings.