### PR TITLE
Allow the base export to be mixed directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ If it is a bug [please open an issue on GitHub](https://github.com/dockyard/embe
 
 ## Usage ##
 
-You need to mixin `EmberValidations.Mixin` into any `Ember.Object` you want to add
+You need to mixin `EmberValidations` into any `Ember.Object` you want to add
 validations to:
 
 ```javascript
 import Ember from 'ember';
 import EmberValidations from 'ember-validations';
 
-export default Ember.ObjectController.extend(EmberValidations.Mixin);
+export default Ember.ObjectController.extend(EmberValidations);
 ```
 
 You define your validations as a JSON object. They should be added to
@@ -383,13 +383,15 @@ any given path the validator will automatically trigger.
 #### Inline Validators ####
 
 If you want to create validators inline you can use the
-`EmberValidations.validator` function:
+`validator` function that is part of the `ember-validations` export:
 
 ```javascript
+import EmberValidations, { validator } from 'ember-validations';
+
 User.create({
   validations: {
     name: {
-      inline: EmberValidations.validator(function() {
+      inline: validator(function() {
         if (this.model.get('canNotDoSomething')) {
           return "you can't do this!"
         }
@@ -447,7 +449,7 @@ user.validate().then(function() {
 
 ## Inspecting Errors ##
 
-After mixing in `EmberValidations.Mixin` into your object it will now have a
+After mixing in `EmberValidations` into your object it will now have a
 `.errors` object. All validation error messages will be placed in there
 for the corresponding property. Errors messages will always be an array.
 
@@ -455,7 +457,7 @@ for the corresponding property. Errors messages will always be an array.
 import Ember from 'ember';
 import EmberValidations from 'ember-validations';
 
-export default Ember.Object.extend(EmberValidations.Mixin, {
+export default Ember.Object.extend(EmberValidations, {
   validations: {
     firstName: { presence: true }
   }

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,13 @@
+# Notes on upgrading between versions
+
+## 2.0.0-alpha.4
+
+* `EmberValidations.Mixin` is no longer used. You can mix `EmberValidations` directly into your controllers:
+
+```javascript
+// now invalid
+export default Ember.Controller.extend(EmberValidations.Mixin, {
+
+// new valid syntax
+export default Ember.Controller.extend(EmberValidations, {
+```

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,6 @@
 import Mixin from 'ember-validations/mixin';
 
-export default {
-  Mixin: Mixin,
-  validator: function(callback) {
-    return { callback: callback };
-  }
-};
+export default Mixin;
+export function validator(callback) {
+  return { callback: callback };
+}

--- a/tests/dummy/app/controllers/foo.js
+++ b/tests/dummy/app/controllers/foo.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import EmberValidations from 'ember-validations';
 
-export default Ember.Controller.extend(EmberValidations.Mixin, {
+export default Ember.Controller.extend(EmberValidations, {
   validations: {
     foo: {
       presence: true

--- a/tests/unit/validate-test.js
+++ b/tests/unit/validate-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import EmberValidations from 'ember-validations';
+import EmberValidations, { validator } from 'ember-validations';
 import buildContainer from '../helpers/build-container';
 import Base from 'ember-validations/validators/base';
 
@@ -11,7 +11,7 @@ var run = Ember.run;
 
 module('Validate test', {
   setup: function() {
-    User = Ember.Object.extend(EmberValidations.Mixin, {
+    User = Ember.Object.extend(EmberValidations, {
       container: buildContainer(),
       validations: {
         firstName: {
@@ -75,7 +75,7 @@ test('runs all validations', function(assert) {
 
 test('can be mixed into an object controller', function(assert) {
   var Controller, controller, user;
-  Controller = Ember.ObjectController.extend(EmberValidations.Mixin, {
+  Controller = Ember.ObjectController.extend(EmberValidations, {
     container: buildContainer(),
     validations: {
       name: {
@@ -105,7 +105,7 @@ test('can be mixed into an array controller', function(assert) {
   var Controller, controller, user, UserController;
   var container = buildContainer();
 
-  UserController = Ember.ObjectController.extend(EmberValidations.Mixin, {
+  UserController = Ember.ObjectController.extend(EmberValidations, {
     container: buildContainer(),
     validations: {
       name: {
@@ -114,7 +114,7 @@ test('can be mixed into an array controller', function(assert) {
     }
   });
   container.register('controller:User', UserController);
-  Controller = Ember.ArrayController.extend(EmberValidations.Mixin, {
+  Controller = Ember.ArrayController.extend(EmberValidations, {
     itemController: 'User',
     container: container,
     validations: {
@@ -149,7 +149,7 @@ var Profile, profile;
 
 module('Relationship validators', {
   setup: function() {
-    Profile = Ember.Object.extend(EmberValidations.Mixin, {
+    Profile = Ember.Object.extend(EmberValidations, {
       container: buildContainer(),
       validations: {
         title: {
@@ -162,7 +162,7 @@ module('Relationship validators', {
       profile = Profile.create({hey: 'yo'});
     });
 
-    User = Ember.Object.extend(EmberValidations.Mixin, {
+    User = Ember.Object.extend(EmberValidations, {
       container: buildContainer()
     });
   }
@@ -348,7 +348,7 @@ module('validator class lookup order', {
     requirejs.clear();
     requirejs.rollback();
 
-    User = Ember.Object.extend(EmberValidations.Mixin, {
+    User = Ember.Object.extend(EmberValidations, {
       container: buildContainer()
     });
   },
@@ -505,7 +505,7 @@ test('should store validators in cache for faster lookup', function(assert) {
 
 module('inline validations', {
   setup: function() {
-    User = Ember.Object.extend(EmberValidations.Mixin, {
+    User = Ember.Object.extend(EmberValidations, {
       container: buildContainer()
     });
   }
@@ -516,7 +516,7 @@ test("mixed validation syntax", function(assert) {
     user = User.create({
       validations: {
         name: {
-          inline: EmberValidations.validator(function() {
+          inline: validator(function() {
             return 'it failed';
           })
         }
@@ -531,7 +531,7 @@ test("concise validation syntax", function(assert) {
   run(function() {
     user = User.create({
       validations: {
-        name: EmberValidations.validator(function() {
+        name: validator(function() {
           return 'it failed';
         })
       }


### PR DESCRIPTION
No longer is EmberValidations.Mixin used directly. You can now mixin
EmberValidations directly into the controller