### PR TITLE
Make the validations service an Ember.Service

### DIFF
--- a/app/services/validations.js
+++ b/app/services/validations.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 var set = Ember.set;
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   init: function() {
     set(this, 'cache', {});
   }


### PR DESCRIPTION
Part of the type checking introduced in https://github.com/emberjs/ember.js/pull/11261 checks to make sure that anything registered to the container as `service:*` is a subclass of `Ember.Service`
