### PR TITLE
Allow BIG and LOW numbers to pass numericality

### DIFF
--- a/addon/patterns.js
+++ b/addon/patterns.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Namespace.create({
-  numericality: /^(-|\+)?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d*)?$/,
+  numericality: /^(-|\+)?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d*)?(e[+-][0-9]+)?$/,
   blank: /^\s*$/
 });


### PR DESCRIPTION
Numbers like 3.012430238457636e-80 and 3.012430238457636e+80

Nobody will enter those directly I guess, but might come up when validating computed properties.