### PR TITLE
extend Errors from DS.Errors

### DIFF
--- a/addon/errors.js
+++ b/addon/errors.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
+import DS from 'ember-data';
 
 var get = Ember.get;
 var set = Ember.set;
 
-export default Ember.Object.extend({
+export default DS.Errors.extend({
   unknownProperty: function(property) {
     set(this, property, Ember.A());
     return get(this, property);


### PR DESCRIPTION
As documented at length in #268, Ember versions 1.11 and up (when coupled with matching ember-data versions) are unable to handle server-side validation failures because ember-validations replaces the `errors` property with its own `Errors` class. By making ember-validations extend `DS.Errors`, everything seems to go back to working. Best yet, the tests are green.