### PR TITLE
Set this.validationErrors and alias this.errors to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ To create a new validator you need to override the `call` function. When
 the validator is run its `call` function is what handles determining if
 the validator is valid or not. Call has access to `this.model`,
 `this.property`. If the validation fails you **must** push the failing
-message onto the validator's `this.errors` array. A simple example of a
+message onto the validator's `this.validationErrors` array. A simple example of a
 validator could be:
 
 ```javascript
@@ -358,7 +358,7 @@ import Ember from 'ember';
 export default Base.extend({
   call: function() {
     if (Ember.isBlank(this.model.get(this.property))) {
-      this.errors.pushObject("cannot be blank");
+      this.validationErrors.pushObject("cannot be blank");
     }
   }
 });
@@ -381,7 +381,7 @@ export default Base.extend({
   },
   call: function() {
     if (Ember.isBlank(this.model.get(this.property))) {
-      this.errors.pushObject("cannot be blank");
+      this.validationErrors.pushObject("cannot be blank");
     }
   }
 });
@@ -463,7 +463,7 @@ user.validate().then(function() {
 ## Inspecting Errors ##
 
 After mixing in `EmberValidations` into your object it will now have a
-`.errors` object. All validation error messages will be placed in there
+`.validationErrors` object. All validation error messages will be placed in there
 for the corresponding property. Errors messages will always be an array.
 
 ```javascript
@@ -483,11 +483,11 @@ import User from 'my-app/models/user';
 user = User.create();
 user.validate().then(null, function() {
   user.get('isValid'); // false
-  user.get('errors.firstName'); // ["can't be blank"]
+  user.get('validationErrors.firstName'); // ["can't be blank"]
   user.set('firstName', 'Brian');
   user.validate().then(function() {
     user.get('isValid'); // true
-    user.get('errors.firstName'); // []
+    user.get('validationErrors.firstName'); // []
   })
 })
 

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -81,9 +81,10 @@ var ArrayValidatorProxy = Ember.ArrayProxy.extend(setValidityMixin, {
 });
 
 export default Ember.Mixin.create(setValidityMixin, {
+  errors: Ember.computed.deprecatingAlias('validationErrors'),
   init: function() {
     this._super();
-    this.errors = Errors.create();
+    this.validationErrors = Errors.create();
     this.dependentValidationKeys = {};
     this.validators = Ember.A();
     if (get(this, 'validations') === undefined) {
@@ -91,14 +92,14 @@ export default Ember.Mixin.create(setValidityMixin, {
     }
     this.buildValidators();
     this.validators.forEach(function(validator) {
-      validator.addObserver('errors.[]', this, function(sender) {
+      validator.addObserver('validationErrors.[]', this, function(sender) {
         var errors = Ember.A();
         this.validators.forEach(function(validator) {
           if (validator.property === sender.property) {
-            errors.addObjects(validator.errors);
+            errors.addObjects(validator.validationErrors);
           }
         }, this);
-        set(this, 'errors.' + sender.property, errors);
+        set(this, 'validationErrors.' + sender.property, errors);
       });
     }, this);
   },
@@ -130,7 +131,7 @@ export default Ember.Mixin.create(setValidityMixin, {
           var errorMessage = this.callback.call(this);
 
           if (errorMessage) {
-            this.errors.pushObject(errorMessage);
+            this.validationErrors.pushObject(errorMessage);
           }
         },
         callback: callback
@@ -155,7 +156,7 @@ export default Ember.Mixin.create(setValidityMixin, {
   validate: function() {
     var self = this;
     return this._validate().then(function(vals) {
-      var errors = get(self, 'errors');
+      var errors = get(self, 'validationErrors');
       if (vals.indexOf(false) > -1) {
         return Ember.RSVP.reject(errors);
       }

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -4,8 +4,9 @@ var get = Ember.get;
 var set = Ember.set;
 
 export default Ember.Object.extend({
+  errors: Ember.computed.deprecatingAlias('validationErrors'),
   init: function() {
-    set(this, 'errors', Ember.A());
+    set(this, 'validationErrors', Ember.A());
     this.dependentValidationKeys = Ember.A();
     this.conditionals = {
       'if': get(this, 'options.if'),
@@ -42,13 +43,13 @@ export default Ember.Object.extend({
       return get(model, key);
     }
   },
-  isValid: Ember.computed.empty('errors.[]'),
+  isValid: Ember.computed.empty('validationErrors.[]'),
   isInvalid: Ember.computed.not('isValid'),
   validate: function() {
     var self = this;
     return this._validate().then(function(success) {
       // Convert validation failures to rejects.
-      var errors = get(self, 'model.errors');
+      var errors = get(self, 'model.validationErrors');
       if (success) {
         return errors;
       } else {
@@ -57,7 +58,7 @@ export default Ember.Object.extend({
     });
   },
   _validate: Ember.on('init', function() {
-    this.errors.clear();
+    this.validationErrors.clear();
     if (this.canValidate()) {
       this.call();
     }

--- a/addon/validators/local/absence.js
+++ b/addon/validators/local/absence.js
@@ -19,7 +19,7 @@ export default Base.extend({
   },
   call: function() {
     if (!Ember.isEmpty(get(this.model, this.property))) {
-      this.errors.pushObject(this.options.message);
+      this.validationErrors.pushObject(this.options.message);
     }
   }
 });

--- a/addon/validators/local/acceptance.js
+++ b/addon/validators/local/acceptance.js
@@ -20,10 +20,10 @@ export default Base.extend({
   call: function() {
     if (this.options.accept) {
       if (get(this.model, this.property) !== this.options.accept) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     } else if (get(this.model, this.property) !== '1' && get(this.model, this.property) !== 1 && get(this.model, this.property) !== true) {
-      this.errors.pushObject(this.options.message);
+      this.validationErrors.pushObject(this.options.message);
     }
   }
 });

--- a/addon/validators/local/confirmation.js
+++ b/addon/validators/local/confirmation.js
@@ -23,7 +23,7 @@ export default Base.extend({
 
     if(!Ember.isEmpty(original) || !Ember.isEmpty(confirmation)) {
       if (original !== confirmation) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     }
   }

--- a/addon/validators/local/exclusion.js
+++ b/addon/validators/local/exclusion.js
@@ -22,18 +22,18 @@ export default Base.extend({
 
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     } else if (this.options['in']) {
       if (Ember.$.inArray(get(this.model, this.property), this.options['in']) !== -1) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     } else if (this.options.range) {
       lower = this.options.range[0];
       upper = this.options.range[1];
 
       if (get(this.model, this.property) >= lower && get(this.model, this.property) <= upper) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     }
   }

--- a/addon/validators/local/format.js
+++ b/addon/validators/local/format.js
@@ -19,12 +19,12 @@ export default Base.extend({
    call: function() {
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     } else if (this.options['with'] && !this.options['with'].test(get(this.model, this.property))) {
-      this.errors.pushObject(this.options.message);
+      this.validationErrors.pushObject(this.options.message);
     } else if (this.options.without && this.options.without.test(get(this.model, this.property))) {
-      this.errors.pushObject(this.options.message);
+      this.validationErrors.pushObject(this.options.message);
     }
   }
 });

--- a/addon/validators/local/inclusion.js
+++ b/addon/validators/local/inclusion.js
@@ -20,18 +20,18 @@ export default Base.extend({
     var lower, upper;
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     } else if (this.options['in']) {
       if (Ember.$.inArray(get(this.model, this.property), this.options['in']) === -1) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     } else if (this.options.range) {
       lower = this.options.range[0];
       upper = this.options.range[1];
 
       if (get(this.model, this.property) < lower || get(this.model, this.property) > upper) {
-        this.errors.pushObject(this.options.message);
+        this.validationErrors.pushObject(this.options.message);
       }
     }
   }

--- a/addon/validators/local/length.js
+++ b/addon/validators/local/length.js
@@ -76,7 +76,7 @@ export default Base.extend({
 
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined && (this.options.is || this.options.minimum)) {
-        this.errors.pushObject(this.renderBlankMessage());
+        this.validationErrors.pushObject(this.renderBlankMessage());
       }
     } else {
       for (key in this.CHECKS) {
@@ -90,7 +90,7 @@ export default Base.extend({
           this.CHECKS[key]
         );
         if (!comparisonResult) {
-          this.errors.pushObject(this.renderMessageFor(key));
+          this.validationErrors.pushObject(this.renderMessageFor(key));
         }
       }
     }

--- a/addon/validators/local/numericality.js
+++ b/addon/validators/local/numericality.js
@@ -62,16 +62,16 @@ export default Base.extend({
 
     if (Ember.isEmpty(get(this.model, this.property))) {
       if (this.options.allowBlank === undefined) {
-        this.errors.pushObject(this.options.messages.numericality);
+        this.validationErrors.pushObject(this.options.messages.numericality);
       }
     } else if (!Patterns.numericality.test(get(this.model, this.property))) {
-      this.errors.pushObject(this.options.messages.numericality);
+      this.validationErrors.pushObject(this.options.messages.numericality);
     } else if (this.options.onlyInteger === true && !(/^[+\-]?\d+$/.test(get(this.model, this.property)))) {
-      this.errors.pushObject(this.options.messages.onlyInteger);
+      this.validationErrors.pushObject(this.options.messages.onlyInteger);
     } else if (this.options.odd  && parseInt(get(this.model, this.property), 10) % 2 === 0) {
-      this.errors.pushObject(this.options.messages.odd);
+      this.validationErrors.pushObject(this.options.messages.odd);
     } else if (this.options.even && parseInt(get(this.model, this.property), 10) % 2 !== 0) {
-      this.errors.pushObject(this.options.messages.even);
+      this.validationErrors.pushObject(this.options.messages.even);
     } else {
       for (check in this.CHECKS) {
         if (this.options[check] === undefined) {
@@ -91,7 +91,7 @@ export default Base.extend({
         );
 
         if (!comparisonResult) {
-          this.errors.pushObject(this.options.messages[check]);
+          this.validationErrors.pushObject(this.options.messages[check]);
         }
       }
     }

--- a/addon/validators/local/presence.js
+++ b/addon/validators/local/presence.js
@@ -18,7 +18,7 @@ export default Base.extend({
   },
   call: function() {
     if (Ember.isBlank(get(this.model, this.property))) {
-      this.errors.pushObject(this.options.message);
+      this.validationErrors.pushObject(this.options.message);
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-validations",
-  "version": "2.0.0-alpha.4",
+  "version": "2.1.0",
   "description": "Validations for Ember Objects",
   "directories": {
     "doc": "doc",
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "https://github.com/dockyard/ember-validations",
+  "repository": "dockyard/ember-validations",
   "engines": {
     "node": ">= 0.10.0"
   },

--- a/test-support/helpers/validate-properties.js
+++ b/test-support/helpers/validate-properties.js
@@ -8,8 +8,8 @@ function validateValues(object, propertyName, values, isTestForValid) {
   var validatedValues = [];
 
   values.forEach(function(value) {
-    function handleValidation(errors) {
-      var hasErrors = object.get('errors.' + propertyName + '.firstObject');
+    function handleValidation() {
+      var hasErrors = object.get('validationErrors.' + propertyName + '.firstObject');
       if ((hasErrors && !isTestForValid) || (!hasErrors && isTestForValid)) {
         validatedValues.push(value);
       }

--- a/tests/unit/conditional-validators-test.js
+++ b/tests/unit/conditional-validators-test.js
@@ -33,7 +33,7 @@ test('if with function', function(assert) {
   run(function(){
     user = User.create();
     promise = user.validate().then(function(){
-      assert.ok(Ember.isEmpty(get(user.errors, 'firstName')));
+      assert.ok(Ember.isEmpty(get(user.validationErrors, 'firstName')));
       var validator = get(user.validators, 'firstObject');
       validator.conditionals['if'] = function(model, property) {
         assert.equal(user, model, "the conditional validator is passed the model being validated");
@@ -41,7 +41,7 @@ test('if with function', function(assert) {
         return true;
       };
       user.validate().then(null, function(){
-        assert.deepEqual(get(user.errors, 'firstName'), ["can't be blank"]);
+        assert.deepEqual(get(user.validationErrors, 'firstName'), ["can't be blank"]);
       });
     });
   });
@@ -65,12 +65,12 @@ test('if with property reference', function(assert) {
     user = User.create();
     set(user, 'canValidate', false);
     promise = user.validate().then(function(){
-      assert.ok(Ember.isEmpty(get(user.errors, 'firstName')));
+      assert.ok(Ember.isEmpty(get(user.validationErrors, 'firstName')));
       set(user, 'canValidate', true);
       user.validate().then(null, function(){
-        assert.deepEqual(get(user.errors, 'firstName'), ["can't be blank"]);
+        assert.deepEqual(get(user.validationErrors, 'firstName'), ["can't be blank"]);
         set(user, 'canValidate', false);
-        assert.deepEqual(get(user.errors, 'firstName'), []);
+        assert.deepEqual(get(user.validationErrors, 'firstName'), []);
       });
     });
   });
@@ -95,13 +95,13 @@ test('if with function reference', function(assert) {
   run(function(){
     user = User.create();
     promise = user.validate().then(function(){
-      assert.ok(Ember.isEmpty(get(user.errors, 'firstName')));
+      assert.ok(Ember.isEmpty(get(user.validationErrors, 'firstName')));
       set(user, 'canValidate', true);
       user.canValidate = function() {
         return true;
       };
       user.validate().then(null, function(){
-        assert.deepEqual(get(user.errors, 'firstName'), ["can't be blank"]);
+        assert.deepEqual(get(user.validationErrors, 'firstName'), ["can't be blank"]);
       });
     });
   });
@@ -126,7 +126,7 @@ test('unless with function', function(assert) {
   run(function(){
     user = User.create();
     promise = user.validate().then(function(){
-      assert.ok(Ember.isEmpty(get(user.errors, 'firstName')));
+      assert.ok(Ember.isEmpty(get(user.validationErrors, 'firstName')));
       var validator = get(user.validators, 'firstObject');
       validator.conditionals['unless'] = function(model, property) {
         assert.equal(user, model, "the conditional validator is passed the model being validated");
@@ -134,7 +134,7 @@ test('unless with function', function(assert) {
         return false;
       };
       user.validate().then(null, function(){
-        assert.deepEqual(get(user.errors, 'firstName'), ["can't be blank"]);
+        assert.deepEqual(get(user.validationErrors, 'firstName'), ["can't be blank"]);
       });
     });
   });
@@ -157,12 +157,12 @@ test('unless with property reference', function(assert) {
   run(function(){
     user = User.create();
     promise = user.validate().then(function(){
-      assert.ok(Ember.isEmpty(get(user.errors, 'firstName')));
+      assert.ok(Ember.isEmpty(get(user.validationErrors, 'firstName')));
       set(user, 'canValidate', false);
       user.validate().then(null, function(){
-        assert.deepEqual(get(user.errors, 'firstName'), ["can't be blank"]);
+        assert.deepEqual(get(user.validationErrors, 'firstName'), ["can't be blank"]);
         set(user, 'canValidate', true);
-        assert.deepEqual(get(user.errors, 'firstName'), []);
+        assert.deepEqual(get(user.validationErrors, 'firstName'), []);
       });
     });
   });
@@ -187,13 +187,13 @@ test('unless with function reference', function(assert) {
   run(function(){
     user = User.create();
     promise = user.validate().then(function(){
-      assert.ok(Ember.isEmpty(get(user.errors, 'firstName')));
+      assert.ok(Ember.isEmpty(get(user.validationErrors, 'firstName')));
       set(user, 'canValidate', true);
       user.canValidate = function() {
         return false;
       };
       user.validate().then(null, function(){
-        assert.deepEqual(get(user.errors, 'firstName'), ["can't be blank"]);
+        assert.deepEqual(get(user.validationErrors, 'firstName'), ["can't be blank"]);
       });
     });
   });

--- a/tests/unit/errors-test.js
+++ b/tests/unit/errors-test.js
@@ -33,14 +33,14 @@ test('validations are run on instantiation', function(assert) {
     user = User.create();
   });
   assert.equal(get(user, 'isValid'), false);
-  assert.deepEqual(get(user, 'errors.name'), ["can't be blank"]);
-  assert.deepEqual(get(user, 'errors.age'), ["can't be blank", 'is not a number']);
+  assert.deepEqual(get(user, 'validationErrors.name'), ["can't be blank"]);
+  assert.deepEqual(get(user, 'validationErrors.age'), ["can't be blank", 'is not a number']);
   run(function() {
     user = User.create({name: 'Brian', age: 33});
   });
   assert.ok(get(user, 'isValid'));
-  assert.ok(Ember.isEmpty(get(user, 'errors.name')));
-  assert.ok(Ember.isEmpty(get(user, 'errors.age')));
+  assert.ok(Ember.isEmpty(get(user, 'validationErrors.name')));
+  assert.ok(Ember.isEmpty(get(user, 'validationErrors.age')));
 });
 
 test('when errors are resolved', function(assert) {
@@ -48,26 +48,26 @@ test('when errors are resolved', function(assert) {
     user = User.create();
   });
   assert.equal(get(user, 'isValid'), false);
-  assert.deepEqual(get(user, 'errors.name'), ["can't be blank"]);
-  assert.deepEqual(get(user, 'errors.age'), ["can't be blank", 'is not a number']);
+  assert.deepEqual(get(user, 'validationErrors.name'), ["can't be blank"]);
+  assert.deepEqual(get(user, 'validationErrors.age'), ["can't be blank", 'is not a number']);
   run(function() {
     set(user, 'name', 'Brian');
   });
   assert.equal(get(user, 'isValid'), false);
-  assert.ok(Ember.isEmpty(get(user, 'errors.name')));
-  assert.deepEqual(get(user, 'errors.age'), ["can't be blank", 'is not a number']);
+  assert.ok(Ember.isEmpty(get(user, 'validationErrors.name')));
+  assert.deepEqual(get(user, 'validationErrors.age'), ["can't be blank", 'is not a number']);
   run(function() {
     set(user, 'age', 'thirty three');
   });
   assert.equal(get(user, 'isValid'), false);
-  assert.ok(Ember.isEmpty(get(user, 'errors.name')));
-  assert.deepEqual(get(user, 'errors.age'), ['is not a number']);
+  assert.ok(Ember.isEmpty(get(user, 'validationErrors.name')));
+  assert.deepEqual(get(user, 'validationErrors.age'), ['is not a number']);
   run(function() {
     set(user, 'age', 33);
   });
   assert.ok(get(user, 'isValid'));
-  assert.ok(Ember.isEmpty(get(user, 'errors.name')));
-  assert.ok(Ember.isEmpty(get(user, 'errors.age')));
+  assert.ok(Ember.isEmpty(get(user, 'validationErrors.name')));
+  assert.ok(Ember.isEmpty(get(user, 'validationErrors.age')));
 });
 
 // test('validations use Ember.I18n.t to render the message if Ember.I18n is present', function() {
@@ -94,16 +94,16 @@ test('when errors are resolved', function(assert) {
       // return Ember.I18n.lookupKey(key, Ember.I18n.translations);
     // }
   // };
-  
+
   // run(function() {
     // user = User.create();
   // });
   // equal(get(user, 'isValid'), false);
-  // assert.deepEqual(get(user, 'errors.name'), ['muss ausgefüllt werden']);
-  // assert.deepEqual(get(user, 'errors.age'), ['muss ausgefüllt werden', 'ist keine Zahl']);
+  // assert.deepEqual(get(user, 'validationErrors.name'), ['muss ausgefüllt werden']);
+  // assert.deepEqual(get(user, 'validationErrors.age'), ['muss ausgefüllt werden', 'ist keine Zahl']);
   // run(function() {
     // set(user, 'age', 'thirty three');
   // });
   // equal(get(user, 'isValid'), false);
-  // assert.deepEqual(get(user, 'errors.age'), ['ist keine Zahl']);
+  // assert.deepEqual(get(user, 'validationErrors.age'), ['ist keine Zahl']);
 // });

--- a/tests/unit/validate-test.js
+++ b/tests/unit/validate-test.js
@@ -524,7 +524,7 @@ test("mixed validation syntax", function(assert) {
     });
   });
 
-  assert.deepEqual(['it failed'], get(user, 'errors.name'));
+  assert.deepEqual(['it failed'], get(user, 'validationErrors.name'));
 });
 
 test("concise validation syntax", function(assert) {
@@ -538,5 +538,5 @@ test("concise validation syntax", function(assert) {
     });
   });
 
-  assert.deepEqual(['it failed'], get(user, 'errors.name'));
+  assert.deepEqual(['it failed'], get(user, 'validationErrors.name'));
 });

--- a/tests/unit/validators/base-test.js
+++ b/tests/unit/validators/base-test.js
@@ -55,7 +55,7 @@ test('inactive validators should be considered valid', function(assert) {
         return canValidate;
       },
       call: function() {
-        this.errors.pushObject("nope");
+        this.validationErrors.pushObject("nope");
       }
     });
   });

--- a/tests/unit/validators/local/absence-test.js
+++ b/tests/unit/validators/local/absence-test.js
@@ -22,11 +22,11 @@ test('when value is not empty', function(assert) {
   run(function(){
     validator = Absence.create({model: model, property: 'attribute', options: options});
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
   run(function() {
     set(model, 'attribute', 'not empty');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when value is made empty', function(assert) {
@@ -36,7 +36,7 @@ test('when value is made empty', function(assert) {
     validator = Absence.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', undefined);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when options is true', function(assert) {
@@ -45,5 +45,5 @@ test('when options is true', function(assert) {
     validator = Absence.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'not empty');
   });
-  assert.deepEqual(validator.errors, ["must be blank"]);
+  assert.deepEqual(validator.validationErrors, ["must be blank"]);
 });

--- a/tests/unit/validators/local/acceptance-test.js
+++ b/tests/unit/validators/local/acceptance-test.js
@@ -23,7 +23,7 @@ test('when attribute is true', function(assert) {
     validator = Acceptance.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', true);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when attribute is not true', function(assert) {
@@ -32,7 +32,7 @@ test('when attribute is not true', function(assert) {
     validator = Acceptance.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', false);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when attribute is value of 1', function(assert) {
@@ -41,7 +41,7 @@ test('when attribute is value of 1', function(assert) {
     validator = Acceptance.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when attribute value is 2 and accept value is 2', function(assert) {
@@ -50,7 +50,7 @@ test('when attribute value is 2 and accept value is 2', function(assert) {
     validator = Acceptance.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 2);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when attribute value is 1 and accept value is 2', function(assert) {
@@ -59,7 +59,7 @@ test('when attribute value is 1 and accept value is 2', function(assert) {
     validator = Acceptance.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when options is true', function(assert) {
@@ -68,7 +68,7 @@ test('when options is true', function(assert) {
     validator = Acceptance.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', false);
   });
-  assert.deepEqual(validator.errors, ['must be accepted']);
+  assert.deepEqual(validator.validationErrors, ['must be accepted']);
 });
 
 test('when no message is passed', function(assert) {
@@ -77,5 +77,5 @@ test('when no message is passed', function(assert) {
     validator = Acceptance.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', false);
   });
-  assert.deepEqual(validator.errors, ['must be accepted']);
+  assert.deepEqual(validator.validationErrors, ['must be accepted']);
 });

--- a/tests/unit/validators/local/confirmation-test.js
+++ b/tests/unit/validators/local/confirmation-test.js
@@ -27,15 +27,15 @@ test('when values match', function(assert) {
     set(model, 'attribute', 'test');
     set(model, 'attributeConfirmation', 'test');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
   run(function() {
     set(model, 'attributeConfirmation', 'newTest');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
   run(function() {
     set(model, 'attribute', 'newTest');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when values do not match', function(assert) {
@@ -44,7 +44,7 @@ test('when values do not match', function(assert) {
     validator = Confirmation.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'test');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when original is null', function(assert) {
@@ -52,7 +52,7 @@ test('when original is null', function(assert) {
     validator = Confirmation.create({model: model, property: 'attribute'});
     model.set('attribute', null);
   });
-  assert.ok(Ember.isEmpty(validator.errors));
+  assert.ok(Ember.isEmpty(validator.validationErrors));
 });
 
 test('when confirmation is null', function(assert) {
@@ -60,7 +60,7 @@ test('when confirmation is null', function(assert) {
     validator = Confirmation.create({model: model, property: 'attribute'});
     model.set('attributeConfirmation', null);
   });
-  assert.ok(Ember.isEmpty(validator.errors));
+  assert.ok(Ember.isEmpty(validator.validationErrors));
 });
 
 test('when options is true', function(assert) {
@@ -69,7 +69,7 @@ test('when options is true', function(assert) {
     validator = Confirmation.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'test');
   });
-  assert.deepEqual(validator.errors, ["doesn't match attribute"]);
+  assert.deepEqual(validator.validationErrors, ["doesn't match attribute"]);
 });
 
 test('message integration on model, prints message on Confirmation property', function(assert) {
@@ -86,6 +86,6 @@ test('message integration on model, prints message on Confirmation property', fu
     set(otherModel, 'attribute', 'test');
   });
 
-  assert.deepEqual(get(otherModel, 'errors.attributeConfirmation'), ["doesn't match attribute"]);
-  assert.deepEqual(get(otherModel, 'errors.attribute'), []);
+  assert.deepEqual(get(otherModel, 'validationErrors.attributeConfirmation'), ["doesn't match attribute"]);
+  assert.deepEqual(get(otherModel, 'validationErrors.attribute'), []);
 });

--- a/tests/unit/validators/local/exclusion-test.js
+++ b/tests/unit/validators/local/exclusion-test.js
@@ -22,7 +22,7 @@ test('when value is not in the list', function(assert) {
     validator = Exclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 4);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when value is in the list', function(assert) {
@@ -31,7 +31,7 @@ test('when value is in the list', function(assert) {
     validator = Exclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when allowing blank', function(assert) {
@@ -39,7 +39,7 @@ test('when allowing blank', function(assert) {
   run(function() {
     validator = Exclusion.create({model: model, property: 'attribute', options: options});
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when not allowing blank', function(assert) {
@@ -48,7 +48,7 @@ test('when not allowing blank', function(assert) {
     validator = Exclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when value is not in the range', function(assert) {
@@ -57,7 +57,7 @@ test('when value is not in the range', function(assert) {
     validator = Exclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 4);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when value is in the range', function(assert) {
@@ -66,7 +66,7 @@ test('when value is in the range', function(assert) {
     validator = Exclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when options is an array', function(assert) {
@@ -75,7 +75,7 @@ test('when options is an array', function(assert) {
     validator = Exclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is reserved']);
+  assert.deepEqual(validator.validationErrors, ['is reserved']);
 });
 
 test('when no message is passed', function(assert) {
@@ -84,5 +84,5 @@ test('when no message is passed', function(assert) {
     validator = Exclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is reserved']);
+  assert.deepEqual(validator.validationErrors, ['is reserved']);
 });

--- a/tests/unit/validators/local/format-test.js
+++ b/tests/unit/validators/local/format-test.js
@@ -22,7 +22,7 @@ test('when matching format', function(assert) {
     validator = Format.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute',  '123');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when not matching format', function(assert) {
@@ -31,7 +31,7 @@ test('when not matching format', function(assert) {
     validator = Format.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'abc');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when allowing blank', function(assert) {
@@ -40,7 +40,7 @@ test('when allowing blank', function(assert) {
     validator = Format.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when not allowing blank', function(assert) {
@@ -49,7 +49,7 @@ test('when not allowing blank', function(assert) {
     validator = Format.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when options is regexp', function(assert) {
@@ -58,7 +58,7 @@ test('when options is regexp', function(assert) {
     validator = Format.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is invalid']);
+  assert.deepEqual(validator.validationErrors, ['is invalid']);
 });
 
 test('when no message is passed', function(assert) {
@@ -67,5 +67,5 @@ test('when no message is passed', function(assert) {
     validator = Format.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is invalid']);
+  assert.deepEqual(validator.validationErrors, ['is invalid']);
 });

--- a/tests/unit/validators/local/inclusion-test.js
+++ b/tests/unit/validators/local/inclusion-test.js
@@ -22,7 +22,7 @@ test('when value is in the list', function(assert) {
     validator = Inclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when value is not in the list', function(assert) {
@@ -31,7 +31,7 @@ test('when value is not in the list', function(assert) {
     validator = Inclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 4);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when allowing blank', function(assert) {
@@ -40,7 +40,7 @@ test('when allowing blank', function(assert) {
     validator = Inclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when not allowing blank', function(assert) {
@@ -49,7 +49,7 @@ test('when not allowing blank', function(assert) {
     validator = Inclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when value is in the range', function(assert) {
@@ -58,7 +58,7 @@ test('when value is in the range', function(assert) {
     validator = Inclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when value is not in the range', function(assert) {
@@ -67,7 +67,7 @@ test('when value is not in the range', function(assert) {
     validator = Inclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 4);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when options is array', function(assert) {
@@ -76,7 +76,7 @@ test('when options is array', function(assert) {
     validator = Inclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is not included in the list']);
+  assert.deepEqual(validator.validationErrors, ['is not included in the list']);
 });
 
 test('when no message is passed', function(assert) {
@@ -85,5 +85,5 @@ test('when no message is passed', function(assert) {
     validator = Inclusion.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is not included in the list']);
+  assert.deepEqual(validator.validationErrors, ['is not included in the list']);
 });

--- a/tests/unit/validators/local/length-test.js
+++ b/tests/unit/validators/local/length-test.js
@@ -22,7 +22,7 @@ test('when allowed length is 3 and value length is 3', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '123');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when allowed length is 3 and value length is 4', function(assert) {
@@ -31,7 +31,7 @@ test('when allowed length is 3 and value length is 4', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '1234');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when allowed length is 3 and value length is 2', function(assert) {
@@ -40,7 +40,7 @@ test('when allowed length is 3 and value length is 2', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '12');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when allowing blank and allowed length is 3', function(assert) {
@@ -49,7 +49,7 @@ test('when allowing blank and allowed length is 3', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when allowing blank and minimum length is 3 and maximum length is 100', function(assert) {
@@ -58,7 +58,7 @@ test('when allowing blank and minimum length is 3 and maximum length is 100', fu
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when not allowing blank and allowed length is 3', function(assert) {
@@ -67,7 +67,7 @@ test('when not allowing blank and allowed length is 3', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when allowed length is 3 and a different tokenizer', function(assert) {
@@ -76,7 +76,7 @@ test('when allowed length is 3 and a different tokenizer', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'one two three');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when allowed length minimum is 3 and value length is 3', function(assert) {
@@ -85,7 +85,7 @@ test('when allowed length minimum is 3 and value length is 3', function(assert) 
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '123');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when allowed length minimum is 3 and value length is 2', function(assert) {
@@ -94,7 +94,7 @@ test('when allowed length minimum is 3 and value length is 2', function(assert) 
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '12');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when allowed length maximum is 3 and value length is 3', function(assert) {
@@ -103,7 +103,7 @@ test('when allowed length maximum is 3 and value length is 3', function(assert) 
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '123');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when allowed length maximum is 3 and value length is 4', function(assert) {
@@ -112,7 +112,7 @@ test('when allowed length maximum is 3 and value length is 4', function(assert) 
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '1234');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when allowed length maximum is 3 and value is blank', function(assert) {
@@ -121,7 +121,7 @@ test('when allowed length maximum is 3 and value is blank', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when options is a number', function(assert) {
@@ -131,7 +131,7 @@ test('when options is a number', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is the wrong length (should be 3 characters)']);
+  assert.deepEqual(validator.validationErrors, ['is the wrong length (should be 3 characters)']);
 });
 
 test('when options is a number and value is undefined', function(assert) {
@@ -140,7 +140,7 @@ test('when options is a number and value is undefined', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is the wrong length (should be 3 characters)']);
+  assert.deepEqual(validator.validationErrors, ['is the wrong length (should be 3 characters)']);
 });
 
 test('when allowed length is 3, value length is 4 and no message is set', function(assert) {
@@ -149,7 +149,7 @@ test('when allowed length is 3, value length is 4 and no message is set', functi
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '1234');
   });
-  assert.deepEqual(validator.errors, ['is the wrong length (should be 3 characters)']);
+  assert.deepEqual(validator.validationErrors, ['is the wrong length (should be 3 characters)']);
 });
 
 test('when allowed length minimum is 3, value length is 2 and no message is set', function(assert) {
@@ -158,7 +158,7 @@ test('when allowed length minimum is 3, value length is 2 and no message is set'
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '12');
   });
-  assert.deepEqual(validator.errors, ['is too short (minimum is 3 characters)']);
+  assert.deepEqual(validator.validationErrors, ['is too short (minimum is 3 characters)']);
 });
 
 test('when allowed length maximum is 3, value length is 4 and no message is set', function(assert) {
@@ -167,7 +167,7 @@ test('when allowed length maximum is 3, value length is 4 and no message is set'
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '1234');
   });
-  assert.deepEqual(validator.errors, ['is too long (maximum is 3 characters)']);
+  assert.deepEqual(validator.validationErrors, ['is too long (maximum is 3 characters)']);
 });
 
 test('when value is non-string, then the value is still checked', function(assert) {
@@ -176,7 +176,7 @@ test('when value is non-string, then the value is still checked', function(asser
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1234);
   });
-  assert.deepEqual(validator.errors, ['is too long (maximum is 3 characters)']);
+  assert.deepEqual(validator.validationErrors, ['is too long (maximum is 3 characters)']);
 });
 
 test('when using a property instead of a number', function(assert) {
@@ -185,13 +185,13 @@ test('when using a property instead of a number', function(assert) {
     validator = Length.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '123');
   });
-  assert.deepEqual(validator.errors, ['is the wrong length (should be 0 characters)']);
+  assert.deepEqual(validator.validationErrors, ['is the wrong length (should be 0 characters)']);
   run(function() {
     set(model, 'countProperty', 3);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
   run(function() {
     set(model, 'countProperty', 5);
   });
-  assert.deepEqual(validator.errors, ['is the wrong length (should be 5 characters)']);
+  assert.deepEqual(validator.validationErrors, ['is the wrong length (should be 5 characters)']);
 });

--- a/tests/unit/validators/local/numericality-test.js
+++ b/tests/unit/validators/local/numericality-test.js
@@ -22,7 +22,7 @@ test('when value is a number', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 123);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when value is a decimal number', function(assert) {
@@ -31,7 +31,7 @@ test('when value is a decimal number', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 123.456);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when value is not a number', function(assert) {
@@ -40,7 +40,7 @@ test('when value is not a number', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'abc123');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when no value', function(assert) {
@@ -49,7 +49,7 @@ test('when no value', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when no value and allowing blank', function(assert) {
@@ -58,7 +58,7 @@ test('when no value and allowing blank', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when bad value and allowing blank', function(assert) {
@@ -67,7 +67,7 @@ test('when bad value and allowing blank', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'abc123');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when only allowing integers and value is integer', function(assert) {
@@ -76,7 +76,7 @@ test('when only allowing integers and value is integer', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 123);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when only allowing integers and value is not integer', function(assert) {
@@ -85,7 +85,7 @@ test('when only allowing integers and value is not integer', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 123.456);
   });
-  assert.deepEqual(validator.errors, ['failed integer validation']);
+  assert.deepEqual(validator.validationErrors, ['failed integer validation']);
 });
 
 test('when only integer and no message is passed', function(assert) {
@@ -94,7 +94,7 @@ test('when only integer and no message is passed', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1.1);
   });
-  assert.deepEqual(validator.errors, ['must be an integer']);
+  assert.deepEqual(validator.validationErrors, ['must be an integer']);
 });
 
 test('when only integer is passed directly', function(assert) {
@@ -103,7 +103,7 @@ test('when only integer is passed directly', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1.1);
   });
-  assert.deepEqual(validator.errors, ['must be an integer']);
+  assert.deepEqual(validator.validationErrors, ['must be an integer']);
 });
 
 test('when only allowing values greater than 10 and value is greater than 10', function(assert) {
@@ -112,7 +112,7 @@ test('when only allowing values greater than 10 and value is greater than 10', f
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when only allowing values greater than 10 and value is 10', function(assert) {
@@ -121,7 +121,7 @@ test('when only allowing values greater than 10 and value is 10', function(asser
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when only allowing values greater than or assert.deepEqual to 10 and value is 10', function(assert) {
@@ -130,7 +130,7 @@ test('when only allowing values greater than or assert.deepEqual to 10 and value
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when only allowing values greater than or assert.deepEqual to 10 and value is 9', function(assert) {
@@ -139,7 +139,7 @@ test('when only allowing values greater than or assert.deepEqual to 10 and value
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 9);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when only allowing values less than 10 and value is less than 10', function(assert) {
@@ -148,7 +148,7 @@ test('when only allowing values less than 10 and value is less than 10', functio
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 9);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when only allowing values less than 10 and value is 10', function(assert) {
@@ -157,7 +157,7 @@ test('when only allowing values less than 10 and value is 10', function(assert) 
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when only allowing values less than or assert.deepEqual to 10 and value is 10', function(assert) {
@@ -166,7 +166,7 @@ test('when only allowing values less than or assert.deepEqual to 10 and value is
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when only allowing values less than or assert.deepEqual to 10 and value is 11', function(assert) {
@@ -174,7 +174,7 @@ test('when only allowing values less than or assert.deepEqual to 10 and value is
   run(function() {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
   });
 });
 
@@ -184,7 +184,7 @@ test('when only allowing values equal to 10 and value is 10', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when only allowing values equal to 10 and value is 11', function(assert) {
@@ -193,7 +193,7 @@ test('when only allowing values equal to 10 and value is 11', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
   });
-  assert.deepEqual(validator.errors, ['failed equal validation']);
+  assert.deepEqual(validator.validationErrors, ['failed equal validation']);
 });
 
 test('when only allowing value equal to 0 and value is 1', function(assert) {
@@ -202,7 +202,7 @@ test('when only allowing value equal to 0 and value is 1', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 1);
   });
-  assert.deepEqual(validator.errors, ['failed equal validation']);
+  assert.deepEqual(validator.validationErrors, ['failed equal validation']);
 });
 
 test('when only allowing odd values and the value is odd', function(assert) {
@@ -211,7 +211,7 @@ test('when only allowing odd values and the value is odd', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when only allowing odd values and the value is even', function(assert) {
@@ -220,7 +220,7 @@ test('when only allowing odd values and the value is even', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when only allowing even values and the value is even', function(assert) {
@@ -229,7 +229,7 @@ test('when only allowing even values and the value is even', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when only allowing even values and the value is odd', function(assert) {
@@ -238,7 +238,7 @@ test('when only allowing even values and the value is odd', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when value refers to another present property', function(assert) {
@@ -248,12 +248,12 @@ test('when value refers to another present property', function(assert) {
     set(model, 'attribute_1', 0);
     set(model, 'attribute_2', 1);
   });
-  assert.deepEqual(validator.errors, ['failed to be greater']);
+  assert.deepEqual(validator.validationErrors, ['failed to be greater']);
   run(function() {
     set(model, 'attribute_1', 2);
     set(model, 'attribute_2', 1);
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when options is true', function(assert) {
@@ -262,7 +262,7 @@ test('when options is true', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['is not a number']);
+  assert.deepEqual(validator.validationErrors, ['is not a number']);
 });
 
 test('when equal to  and no message is passed', function(assert) {
@@ -271,7 +271,7 @@ test('when equal to  and no message is passed', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, ['must be equal to 11']);
+  assert.deepEqual(validator.validationErrors, ['must be equal to 11']);
 });
 
 test('when greater than and no message is passed', function(assert) {
@@ -280,7 +280,7 @@ test('when greater than and no message is passed', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, ['must be greater than 11']);
+  assert.deepEqual(validator.validationErrors, ['must be greater than 11']);
 });
 
 test('when greater than or equal to and no message is passed', function(assert) {
@@ -289,7 +289,7 @@ test('when greater than or equal to and no message is passed', function(assert) 
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, ['must be greater than or equal to 11']);
+  assert.deepEqual(validator.validationErrors, ['must be greater than or equal to 11']);
 });
 
 test('when less than and no message is passed', function(assert) {
@@ -298,7 +298,7 @@ test('when less than and no message is passed', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
   });
-  assert.deepEqual(validator.errors, ['must be less than 10']);
+  assert.deepEqual(validator.validationErrors, ['must be less than 10']);
 });
 
 test('when less than or equal to and no message is passed', function(assert) {
@@ -307,7 +307,7 @@ test('when less than or equal to and no message is passed', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
   });
-  assert.deepEqual(validator.errors, ['must be less than or equal to 10']);
+  assert.deepEqual(validator.validationErrors, ['must be less than or equal to 10']);
 });
 
 test('when odd and no message is passed', function(assert) {
@@ -316,7 +316,7 @@ test('when odd and no message is passed', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 10);
   });
-  assert.deepEqual(validator.errors, ['must be odd']);
+  assert.deepEqual(validator.validationErrors, ['must be odd']);
 });
 
 test('when even and no message is passed', function(assert) {
@@ -325,7 +325,7 @@ test('when even and no message is passed', function(assert) {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
   });
-  assert.deepEqual(validator.errors, ['must be even']);
+  assert.deepEqual(validator.validationErrors, ['must be even']);
 });
 
 test('when other messages are passed but not a numericality message', function(assert) {
@@ -334,7 +334,7 @@ test('when other messages are passed but not a numericality message', function(a
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'abc');
   });
-  assert.deepEqual(validator.errors, ['is not a number']);
+  assert.deepEqual(validator.validationErrors, ['is not a number']);
 });
 
 test('when greaterThan fails and a greaterThan message is passed but not a numericality message', function(assert) {
@@ -343,7 +343,7 @@ test('when greaterThan fails and a greaterThan message is passed but not a numer
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     model.set('attribute', 10);
   });
-  assert.deepEqual(validator.errors, ['custom message']);
+  assert.deepEqual(validator.validationErrors, ['custom message']);
 });
 
 test("numericality validators don't call addObserver on null props", function(assert) {

--- a/tests/unit/validators/local/presence-test.js
+++ b/tests/unit/validators/local/presence-test.js
@@ -22,7 +22,7 @@ test('when value is not empty', function(assert) {
     validator = Presence.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 'not empty');
   });
-  assert.deepEqual(validator.errors, []);
+  assert.deepEqual(validator.validationErrors, []);
 });
 
 test('when value is empty', function(assert) {
@@ -31,7 +31,7 @@ test('when value is empty', function(assert) {
     validator = Presence.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });
 
 test('when options is true', function(assert) {
@@ -40,7 +40,7 @@ test('when options is true', function(assert) {
     validator = Presence.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', '');
   });
-  assert.deepEqual(validator.errors, ["can't be blank"]);
+  assert.deepEqual(validator.validationErrors, ["can't be blank"]);
 });
 
 test('when value is blank', function(assert) {
@@ -49,5 +49,5 @@ test('when value is blank', function(assert) {
     validator = Presence.create({model: model, property: 'attribute', options: options});
     model.set('attribute', ' ');
   });
-  assert.deepEqual(validator.errors, ['failed validation']);
+  assert.deepEqual(validator.validationErrors, ['failed validation']);
 });


### PR DESCRIPTION
Permits resolution of namespace conflict with the errors property used by Ember Data [DS.Errors](http://emberjs.com/api/data/classes/DS.Errors.html) while maintaining backward compatibility.

Ember Data sets `this.errors` in [`RESTAdapter.handleResponse`](http://emberjs.com/api/data/classes/DS.RESTAdapter.html#method_handleResponse).