### PR TITLE
Fix deprecation warnings on container in ember 2.3 

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Errors from 'ember-validations/errors';
 import Base from 'ember-validations/validators/base';
+import getOwner from 'ember-getowner-polyfill';
 
 var get = Ember.get;
 var set = Ember.set;
@@ -29,8 +30,8 @@ var pushValidatableObject = function(model, property) {
 };
 
 var lookupValidator = function(validatorName) {
-  var container = get(this, 'container');
-  var service = container.lookup('service:validations');
+  var owner = getOwner(this);
+  var service = owner.lookup('service:validations');
   var validators = [];
   var cache;
 
@@ -43,17 +44,17 @@ var lookupValidator = function(validatorName) {
   if (cache[validatorName]) {
     validators = validators.concat(cache[validatorName]);
   } else {
-    var local = container.lookupFactory('validator:local/'+validatorName);
-    var remote = container.lookupFactory('validator:remote/'+validatorName);
+    var local = owner._lookupFactory('validator:local/'+validatorName);
+    var remote = owner._lookupFactory('validator:remote/'+validatorName);
 
     if (local || remote) { validators = validators.concat([local, remote]); }
     else {
-      var base = container.lookupFactory('validator:'+validatorName);
+      var base = owner._lookupFactory('validator:'+validatorName);
 
       if (base) { validators = validators.concat([base]); }
       else {
-        local = container.lookupFactory('ember-validations@validator:local/'+validatorName);
-        remote = container.lookupFactory('ember-validations@validator:remote/'+validatorName);
+        local = owner._lookupFactory('ember-validations@validator:local/'+validatorName);
+        remote = owner._lookupFactory('ember-validations@validator:remote/'+validatorName);
 
         if (local || remote) { validators = validators.concat([local, remote]); }
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-getowner-polyfill": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
"In Ember 2.3, accessing the container property on a framework-generated object will be deprecated in favor of a public owner API."

http://emberjs.com/deprecations/v2.x/#toc_injected-container-access

Using the https://github.com/rwjblue/ember-getowner-polyfill backports this fix to work with older ember versions >= 1.10 