### PR TITLE
Presence validation on belongsTo

### DIFF
--- a/addon/validators/local/presence.js
+++ b/addon/validators/local/presence.js
@@ -17,7 +17,7 @@ export default Base.extend({
     }
   },
   call: function() {
-    if (Ember.isBlank(get(this.model, this.property))) {
+    if (Ember.isBlank(get(this.model, this.property)) || typeof get(this.model, this.property) === 'object' && Ember.isEmpty(get(this.model, this.property).get('content'))) {
       this.errors.pushObject(this.options.message);
     }
   }


### PR DESCRIPTION
This adds presence validation to belongsTo relationships.
The issue with isBlank on belongsTo validation is that the belongsTo property itself is never blank, it is a promise at all times, however the content of this promise can and will be empty if the property is not set.