### PR TITLE
Add Support for Validating Asynchronous Properties

### DIFF
--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -75,32 +75,17 @@ export default Ember.Object.extend({
       this.handlePropertyRetrievalError(error);
     });
   }),
-
   canValidate: function() {
-    if (typeof(this.conditionals) === 'object') {
-      if (this.conditionals['if']) {
-        if (typeof(this.conditionals['if']) === 'function') {
-          return this.conditionals['if'](this.model, this.property);
-        } else if (typeof(this.conditionals['if']) === 'string') {
-          if (typeof(this.model[this.conditionals['if']]) === 'function') {
-            return this.model[this.conditionals['if']]();
-          } else {
-            return get(this.model, this.conditionals['if']);
-          }
-        }
-      } else if (this.conditionals.unless) {
-        if (typeof(this.conditionals.unless) === 'function') {
-          return !this.conditionals.unless(this.model, this.property);
-        } else if (typeof(this.conditionals.unless) === 'string') {
-          if (typeof(this.model[this.conditionals.unless]) === 'function') {
-            return !this.model[this.conditionals.unless]();
-          } else {
-            return !get(this.model, this.conditionals.unless);
-          }
-        }
-      } else {
-        return true;
-      }
+    let conditionals = this.conditionals;
+    if (typeof(conditionals) !== 'object') { return true; }
+
+    let ifConditional = conditionals['if'];
+    let unlessConditional = conditionals['unless'];
+
+    if (ifConditional) {
+      return this._handleConditional(ifConditional, false);
+    } else if (unlessConditional) {
+      return this._handleConditional(unlessConditional, true);
     } else {
       return true;
     }
@@ -115,5 +100,21 @@ export default Ember.Object.extend({
       case '<':   return a < b;
       default:    return false;
     }
+  },
+  // invert handles the unless condition
+  _handleConditional(conditional, invert=false) {
+    let result;
+
+    if (typeof(conditional) === 'function') {
+      result = conditional(this.model, this.property);
+    } else if (typeof(conditional) === 'string') {
+      result = get(this.model, conditional);
+
+      if (typeof(this.model[conditional]) === 'function') {
+        result = this.model[conditional]();
+      }
+    }
+
+    return invert ? !result : result;
   }
 });

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -29,8 +29,7 @@ export default Ember.Object.extend({
   }),
   pushDependentValidationKeyToModel: on('init', function() {
     let model = get(this, 'model');
-    let dependentValidationKeys = model.dependentValidationKeys[this.property];
-    if (dependentValidationKeys === undefined) {
+    if (model.dependentValidationKeys[this.property] === undefined) {
       model.dependentValidationKeys[this.property] = new A();
     }
     model.dependentValidationKeys[this.property].addObjects(this.dependentValidationKeys);

--- a/addon/validators/local/absence.js
+++ b/addon/validators/local/absence.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import Base from 'ember-validations/validators/base';
 import Messages from 'ember-validations/messages';
 
-var get = Ember.get;
 var set = Ember.set;
 
 export default Base.extend({
@@ -17,8 +16,8 @@ export default Base.extend({
       set(this, 'options.message', Messages.render('present', this.options));
     }
   },
-  call: function() {
-    if (!Ember.isEmpty(get(this.model, this.property))) {
+  call(value) {
+    if (!Ember.isEmpty(value)) {
       this.errors.pushObject(this.options.message);
     }
   }

--- a/addon/validators/local/acceptance.js
+++ b/addon/validators/local/acceptance.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import Base from 'ember-validations/validators/base';
 import Messages from 'ember-validations/messages';
 
-var get = Ember.get;
 var set = Ember.set;
 
 export default Base.extend({
@@ -17,12 +16,12 @@ export default Base.extend({
       set(this, 'options.message', Messages.render('accepted', this.options));
     }
   },
-  call: function() {
+  call(value) {
     if (this.options.accept) {
-      if (get(this.model, this.property) !== this.options.accept) {
+      if (value !== this.options.accept) {
         this.errors.pushObject(this.options.message);
       }
-    } else if (get(this.model, this.property) !== '1' && get(this.model, this.property) !== 1 && get(this.model, this.property) !== true) {
+    } else if (value !== '1' && value !== 1 && value !== true) {
       this.errors.pushObject(this.options.message);
     }
   }

--- a/addon/validators/local/confirmation.js
+++ b/addon/validators/local/confirmation.js
@@ -17,9 +17,9 @@ export default Base.extend({
       set(this, 'options', { message: Messages.render('confirmation', this.options) });
     }
   },
-  call: function() {
+  call(value) {
     var original = get(this.model, this.originalProperty);
-    var confirmation = get(this.model, this.property);
+    var confirmation = value;
 
     if(!Ember.isEmpty(original) || !Ember.isEmpty(confirmation)) {
       if (original !== confirmation) {

--- a/addon/validators/local/exclusion.js
+++ b/addon/validators/local/exclusion.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import Base from 'ember-validations/validators/base';
 import Messages from 'ember-validations/messages';
 
-var get = Ember.get;
 var set = Ember.set;
 
 export default Base.extend({
@@ -16,23 +15,23 @@ export default Base.extend({
       set(this, 'options.message', Messages.render('exclusion', this.options));
     }
   },
-  call: function() {
+  call(value) {
     /*jshint expr:true*/
     var lower, upper;
 
-    if (Ember.isEmpty(get(this.model, this.property))) {
+    if (Ember.isEmpty(value)) {
       if (this.options.allowBlank === undefined) {
         this.errors.pushObject(this.options.message);
       }
     } else if (this.options['in']) {
-      if (Ember.$.inArray(get(this.model, this.property), this.options['in']) !== -1) {
+      if (Ember.$.inArray(value, this.options['in']) !== -1) {
         this.errors.pushObject(this.options.message);
       }
     } else if (this.options.range) {
       lower = this.options.range[0];
       upper = this.options.range[1];
 
-      if (get(this.model, this.property) >= lower && get(this.model, this.property) <= upper) {
+      if (value >= lower && value <= upper) {
         this.errors.pushObject(this.options.message);
       }
     }

--- a/addon/validators/local/format.js
+++ b/addon/validators/local/format.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import Base from 'ember-validations/validators/base';
 import Messages from 'ember-validations/messages';
 
-var get = Ember.get;
 var set = Ember.set;
 
 export default Base.extend({
@@ -16,14 +15,14 @@ export default Base.extend({
       set(this, 'options.message',  Messages.render('invalid', this.options));
     }
    },
-   call: function() {
-    if (Ember.isEmpty(get(this.model, this.property))) {
+   call(value) {
+    if (Ember.isEmpty(value)) {
       if (this.options.allowBlank === undefined) {
         this.errors.pushObject(this.options.message);
       }
-    } else if (this.options['with'] && !this.options['with'].test(get(this.model, this.property))) {
+    } else if (this.options['with'] && !this.options['with'].test(value)) {
       this.errors.pushObject(this.options.message);
-    } else if (this.options.without && this.options.without.test(get(this.model, this.property))) {
+    } else if (this.options.without && this.options.without.test(value)) {
       this.errors.pushObject(this.options.message);
     }
   }

--- a/addon/validators/local/inclusion.js
+++ b/addon/validators/local/inclusion.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import Base from 'ember-validations/validators/base';
 import Messages from 'ember-validations/messages';
 
-var get = Ember.get;
 var set = Ember.set;
 
 export default Base.extend({
@@ -16,21 +15,21 @@ export default Base.extend({
       set(this, 'options.message', Messages.render('inclusion', this.options));
     }
   },
-  call: function() {
+  call(value) {
     var lower, upper;
-    if (Ember.isEmpty(get(this.model, this.property))) {
+    if (Ember.isEmpty(value)) {
       if (this.options.allowBlank === undefined) {
         this.errors.pushObject(this.options.message);
       }
     } else if (this.options['in']) {
-      if (Ember.$.inArray(get(this.model, this.property), this.options['in']) === -1) {
+      if (Ember.$.inArray(value, this.options['in']) === -1) {
         this.errors.pushObject(this.options.message);
       }
     } else if (this.options.range) {
       lower = this.options.range[0];
       upper = this.options.range[1];
 
-      if (get(this.model, this.property) < lower || get(this.model, this.property) > upper) {
+      if (value < lower || value > upper) {
         this.errors.pushObject(this.options.message);
       }
     }

--- a/addon/validators/local/length.js
+++ b/addon/validators/local/length.js
@@ -71,10 +71,10 @@ export default Base.extend({
       return this.renderMessageFor('minimum');
     }
   },
-  call: function() {
+  call(value) {
     var key, comparisonResult;
 
-    if (Ember.isEmpty(get(this.model, this.property))) {
+    if (Ember.isEmpty(value)) {
       if (this.options.allowBlank === undefined && (this.options.is || this.options.minimum)) {
         this.errors.pushObject(this.renderBlankMessage());
       }
@@ -85,7 +85,7 @@ export default Base.extend({
         }
 
         comparisonResult = this.compare(
-          this.options.tokenizer(get(this.model, this.property)).length,
+          this.options.tokenizer(value).length,
           this.getValue(key),
           this.CHECKS[key]
         );

--- a/addon/validators/local/numericality.js
+++ b/addon/validators/local/numericality.js
@@ -57,20 +57,20 @@ export default Base.extend({
     lessThan             : '<',
     lessThanOrEqualTo    : '<='
   },
-  call: function() {
+  call(value) {
     var check, checkValue, comparisonResult;
 
-    if (Ember.isEmpty(get(this.model, this.property))) {
+    if (Ember.isEmpty(value)) {
       if (this.options.allowBlank === undefined) {
         this.errors.pushObject(this.options.messages.numericality);
       }
-    } else if (!Patterns.numericality.test(get(this.model, this.property))) {
+    } else if (!Patterns.numericality.test(value)) {
       this.errors.pushObject(this.options.messages.numericality);
-    } else if (this.options.onlyInteger === true && !(/^[+\-]?\d+$/.test(get(this.model, this.property)))) {
+    } else if (this.options.onlyInteger === true && !(/^[+\-]?\d+$/.test(value))) {
       this.errors.pushObject(this.options.messages.onlyInteger);
-    } else if (this.options.odd  && parseInt(get(this.model, this.property), 10) % 2 === 0) {
+    } else if (this.options.odd  && parseInt(value, 10) % 2 === 0) {
       this.errors.pushObject(this.options.messages.odd);
-    } else if (this.options.even && parseInt(get(this.model, this.property), 10) % 2 !== 0) {
+    } else if (this.options.even && parseInt(value, 10) % 2 !== 0) {
       this.errors.pushObject(this.options.messages.even);
     } else {
       for (check in this.CHECKS) {
@@ -85,7 +85,7 @@ export default Base.extend({
         }
 
         comparisonResult = this.compare(
-          get(this.model, this.property),
+          value,
           checkValue,
           this.CHECKS[check]
         );

--- a/addon/validators/local/presence.js
+++ b/addon/validators/local/presence.js
@@ -2,8 +2,6 @@ import Ember from 'ember';
 import Base from 'ember-validations/validators/base';
 import Messages from 'ember-validations/messages';
 
-var get = Ember.get;
-
 export default Base.extend({
   init: function() {
     this._super();
@@ -16,8 +14,8 @@ export default Base.extend({
       this.options.message = Messages.render('blank', this.options);
     }
   },
-  call: function() {
-    if (Ember.isBlank(get(this.model, this.property))) {
+  call(value) {
+    if (Ember.isBlank(value)) {
       this.errors.pushObject(this.options.message);
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-htmlbars": "0.7.4",
-    "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.10",
     "ember-cli-uglify": "1.0.1",

--- a/tests/unit/validators/base-test.js
+++ b/tests/unit/validators/base-test.js
@@ -64,3 +64,157 @@ test('inactive validators should be considered valid', function(assert) {
   run(validator, 'validate');
   assert.equal(get(validator, 'isValid'), true);
 });
+
+test('dependent properties can be promises', function(assert) {
+  assert.expect(1);
+
+  model.reopen({
+    boop: Ember.computed(function() {
+      return new Ember.RSVP.Promise((resolve) => {
+        Ember.run.later(function() {
+          resolve('somevalue');
+        }, 250);
+      });
+    })
+  });
+
+  validator = CustomValidator.createWithMixins({
+    model: model,
+    property: 'boop',
+    call(value) {
+      if (value !== 'somevalue') {
+        this.errors.pushObject('oh no you don\'t');
+      }
+    }
+  });
+
+  return validator.validate()
+                  .then(() => {
+                    assert.deepEqual(validator.errors, []);
+                  });
+});
+
+test('promised property validations errors add to the errors array', function(assert) {
+  assert.expect(1);
+
+  model.reopen({
+    boop: Ember.computed(function() {
+      return new Ember.RSVP.Promise((resolve) => {
+        Ember.run.later(function() {
+          resolve('somevalue');
+        }, 250);
+      });
+    })
+  });
+
+  validator = CustomValidator.createWithMixins({
+    model: model,
+    property: 'boop',
+    call(value) {
+      if (value === 'somevalue') {
+        this.errors.pushObject('oh no you don\'t');
+      }
+    }
+  });
+
+  return validator.validate()
+                  .catch(() => {
+                    assert.deepEqual(validator.errors, ['oh no you don\'t']);
+                  });
+});
+
+test('rejected properties call a handlePropertyRetrievalError method', function(assert) {
+  // _validate gets called on init, as well as on validate() so we're expecting
+  // two assertions
+  assert.expect(2);
+
+  model.reopen({
+    boop: Ember.computed(function() {
+      return new Ember.RSVP.Promise((resolve, reject) => {
+        Ember.run.later(function() {
+          reject('well shoot');
+        }, 250);
+      });
+    })
+  });
+
+  validator = CustomValidator.create({
+    model: model,
+    property: 'boop',
+    handlePropertyRetrievalError(error) {
+      assert.equal(error, 'well shoot');
+    }
+  });
+
+  return validator.validate().catch(() => {});
+});
+
+test('the default handlePropertyRetrievalError pushes the error into this.errors', function(assert) {
+  model.reopen({
+    boop: Ember.computed(function() {
+      return new Ember.RSVP.Promise((resolve, reject) => {
+        Ember.run.later(function() {
+          reject('well shoot');
+        }, 250);
+      });
+    })
+  });
+
+  validator = CustomValidator.create({
+    model: model,
+    property: 'boop'
+  });
+
+  // _validate gets called on init, as well as on validate() so we're expecting
+  // two entries
+  return validator.validate().catch(() => {
+    assert.deepEqual(validator.errors, ['well shoot', 'well shoot']);
+  });
+});
+
+test('dependent properties can become promises', function(assert) {
+  assert.expect(2);
+
+  model.reopen({
+    boop: Ember.computed(function() {
+      return new Ember.RSVP.Promise((resolve) => {
+        Ember.run.later(function() {
+          resolve(true);
+        }, 250);
+      });
+    })
+  });
+
+  validator = CustomValidator.createWithMixins({
+    model: model,
+    property: 'boop',
+    call(value) {
+      if (!value) {
+        this.errors.pushObject('nope');
+      }
+    }
+  });
+
+  return validator.validate()
+                  .then(function() {
+                    assert.deepEqual(validator.errors, []);
+                  }).then(function() {
+                    validator.model.set('boop', Ember.computed(function() {
+                      return new Ember.RSVP.Promise((resolve) => {
+                        Ember.run.later(function() {
+                          resolve(false);
+                        }, 250);
+                      });
+                    }));
+
+                    // add a small delay so the promise has had time to resolve
+                    // I don't want to call validate() and force a validation
+                    return new Ember.RSVP.Promise((resolve) => {
+                      Ember.run.later(function() {
+                        assert.deepEqual(validator.errors, ['nope']);
+                        resolve();
+                      }, 500);
+                    });
+                  });
+
+});

--- a/tests/unit/validators/local/numericality-test.js
+++ b/tests/unit/validators/local/numericality-test.js
@@ -174,8 +174,8 @@ test('when only allowing values less than or assert.deepEqual to 10 and value is
   run(function() {
     validator = Numericality.create({model: model, property: 'attribute', options: options});
     set(model, 'attribute', 11);
-  assert.deepEqual(validator.errors, ['failed validation']);
   });
+  assert.deepEqual(validator.errors, ['failed validation']);
 });
 
 test('when only allowing values equal to 10 and value is 10', function(assert) {


### PR DESCRIPTION
The `base` validator is promise-based, but the individual validators are synchronous. This centralizes the getter into the `base` validator, waits for the property to resolve, synchronously or asynchronously, and passes the value into the individual validators. 

The individual validators have not changed much. They just use the value passed into them now instead of calling `get` themselves everywhere.

This is a bit of a stop-gap solution as I think long-term, the individual `call()` methods should return a promise so they can execute asynchronously.
