### PR TITLE
Fix ember-getowner-polyfill deprecation

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import Errors from 'ember-validations/errors';
 import Base from 'ember-validations/validators/base';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   A: emberArray,
@@ -42,7 +41,7 @@ const pushValidatableObject = function(model, property) {
 };
 
 const lookupValidator = function(validatorName) {
-  let owner = getOwner(this);
+  let owner = Ember.getOwner(this);
   let service = owner.lookup('service:validations');
   let validators = [];
   let cache;

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -113,6 +113,8 @@ export default Mixin.create(setValidityMixin, {
 
     if (get(this, 'validations') === undefined) {
       this.validations = {};
+    } else {
+      this.validations = get(this, 'validations');
     }
 
     this.buildValidators();

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Also adds support for validations as an immutable computed property