### PR TITLE
Update usage of getOwner

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import Errors from 'ember-validations/errors';
 import Base from 'ember-validations/validators/base';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   A: emberArray,
@@ -11,6 +10,7 @@ const {
   computed,
   computed: { alias, not },
   get,
+  getOwner,
   isArray,
   isNone,
   isPresent,


### PR DESCRIPTION
Now the polyfill is a **real** polyfill, so we can destructure from ember itself.

This is a subset of the changes in #447 in the hope CI is green and it can be merge faster.